### PR TITLE
Fix collapsible sidebar and button text wrapping

### DIFF
--- a/game.html
+++ b/game.html
@@ -9,6 +9,7 @@
 <body>
 
 <div id="sidebar" aria-label="Game sidebar with stats">
+  <button id="collapse-btn" aria-label="Collapse sidebar">&lt;</button>
   <section id="character-status" aria-label="Character status">
     <h2>Character Status</h2>
     <div class="stat">

--- a/style.css
+++ b/style.css
@@ -178,6 +178,14 @@ main {
 }
 
 /* Buttons */
+.nav-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center; /* Vertically align items */
+}
+
 .nav-buttons a, .nav-buttons button {
   background: transparent;
   color: var(--color-primary);
@@ -189,7 +197,6 @@ main {
   box-shadow: none;
   border: 2px solid var(--color-primary);
   flex-grow: 1;
-  flex-basis: 200px;
   text-align: center;
 }
 .nav-buttons a:hover, .nav-buttons button:hover {


### PR DESCRIPTION
This commit addresses two UI issues:

1. The sidebar collapsible button was not functional because the corresponding HTML element was missing. This has been fixed by adding the `<button id="collapse-btn">` to `game.html`, allowing the existing JavaScript to hook into it.

2. Buttons with long text (e.g., "Return to the valley") were having their text cut off or wrapped improperly. This was caused by the navigation container not being a flex container. The `.nav-buttons` class has been updated to use `display: flex` with `flex-wrap: wrap`, ensuring buttons now wrap gracefully onto new lines when space is limited. The `flex-basis` was also removed to allow buttons to size more naturally to their content.